### PR TITLE
241217

### DIFF
--- a/src/dfs와_bfs_1260.java
+++ b/src/dfs와_bfs_1260.java
@@ -1,0 +1,75 @@
+import java.io.*;
+import java.util.*;
+
+/*******************************************************************************
+ * 소요시간: 20분
+ * 시간복잡도: O(n^2)
+ *      * 인접 행렬 사용했으므로 모든 노드 간의 연결 여부를 확인해야 하기에, O(n^2)
+ * 메모리: 24528 kb
+ * 시간: 296 ms
+ *******************************************************************************/
+
+public class dfs와_bfs_1260 {
+    private static int n, m, v;
+    private static int[][] matrix;
+    private static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        v = Integer.parseInt(st.nextToken());
+
+        matrix = new int[n + 1][n + 1];
+        visited = new boolean[n + 1];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            matrix[a][b] = 1;
+            matrix[b][a] = 1;
+        }
+
+        visited[v] = true;
+        dfs(v);
+        System.out.println();
+
+        // 초기화
+        visited = new boolean[n + 1];
+        bfs(v);
+    }
+
+    private static void dfs(int node) { // O(n^2)
+        System.out.print(node + " ");
+
+        for (int next = 1; next <= n; next++) {
+            if (!visited[next] && matrix[node][next] == 1) {
+                visited[next] = true;
+                dfs(next);
+            }
+        }
+    }
+
+    private static void bfs(int node) { // O(n^2)
+        Queue<Integer> queue = new LinkedList<>();
+        queue.offer(node);
+        visited[node] = true;
+
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+            System.out.print(cur + " ");
+
+            for (int next = 1; next <= n; next++) {
+                if (!visited[next] && matrix[cur][next] == 1) {
+                    visited[next] = true;
+                    queue.offer(next);
+                }
+            }
+        }
+        System.out.println();
+    }
+}

--- a/src/퇴사_14501.java
+++ b/src/퇴사_14501.java
@@ -1,0 +1,38 @@
+import java.io.*;
+import java.util.*;
+
+/*******************************************************************************
+ * 소요시간: 1시간
+ * 시간복잡도: O(n^2)
+ * 메모리: 14324 kb
+ * 시간: 100 ms
+ *******************************************************************************/
+
+public class 퇴사_14501 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int[] tArr = new int[n];
+        int[] pArr = new int[n];
+        int[] dp = new int[n + 1]; // 당일에 받을 수 있는 최대 금액 저장
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            tArr[i] = Integer.parseInt(st.nextToken());
+            pArr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) { // O(n)
+            int paidDay = i + tArr[i]; // 상담 후 금액 받는 날
+
+            for (int j = paidDay; j <= n; j++) { // O(n)
+                // 마지막날 끝나는 상담의 금액이 dp[n]에 담기므로 연산자(<=) 사용
+                if (dp[j] < dp[i] + pArr[i]) {
+                    dp[j] = dp[i] + pArr[i];
+                }
+            }
+        }
+        System.out.println(dp[n]);
+    }
+}


### PR DESCRIPTION
##  1260 DFS와 BFS 
 * 소요시간: 20분
 * 시간복잡도: O(n^2)
      * 인접 행렬 사용했으므로 모든 노드 간의 연결 여부를 확인해야 하기에, O(n^2)
 * 메모리: 24528 kb
 * 시간: 296 ms
### 간단한 풀이
- 인접행렬 사용했으므로 시간복잡도 O(n^2)
- 인접리스트 사용했다면 O(V+E)로 시간 줄일 수 있겠다,, 

## 14501 퇴사 
 * 소요시간: 1시간
 * 시간복잡도: O(n^2)
 * 메모리: 14324 kb
 * 시간: 100 ms
### 간단한 풀이 
- 점화식: dp[j] = dp[i] + pArr[i]
- 위 점화식을 사용하되, 금액지불날 이후 배열(dp)을 순차적으로 돌아, 받을 수 있는 최고 금액을 갱신할 수 있다면 갱신하는 로직 추가 

dp가 너무 어려워요 ,, 